### PR TITLE
Misc fixes

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -50,6 +50,25 @@ def doFileUpload(file, allowedExtensions, fileTypeName):
 	file.save(os.path.join("app/public/uploads", filename))
 	return "/uploads/" + filename
 
+def make_flask_user_password(plaintext_str):
+	# http://passlib.readthedocs.io/en/stable/modular_crypt_format.html
+	# http://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt.html#format-algorithm
+	# Flask_User stores passwords in the Modular Crypt Format.
+	# https://github.com/lingthio/Flask-User/blob/master/flask_user/user_manager__settings.py#L166
+	#   Note that Flask_User allows customizing password algorithms.
+	#   USER_PASSLIB_CRYPTCONTEXT_SCHEMES defaults to bcrypt but if
+	#   default changes or is customized, the code below needs adapting.
+	# Individual password values will look like:
+	#   $2b$12$.az4S999Ztvy/wa3UdQvMOpcki1Qn6VYPXmEFMIdWQyYs7ULnH.JW
+	#   $XX$RR$SSSSSSSSSSSSSSSSSSSSSSHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
+	# $XX : Selects algorithm (2b is bcrypt).
+	# $RR : Selects bcrypt key expansion rounds (12 is 2**12 rounds).
+	# $SSS... : 22 chars of (random, per-password) salt
+	#  HHH... : 31 remaining chars of password hash (note no dollar sign)
+	import bcrypt
+	plaintext = plaintext_str.encode("UTF-8")
+	password = bcrypt.hashpw(plaintext, bcrypt.gensalt())
+	return password.decode("UTF-8")
 
 def _do_login_user(user, remember_me=False):
 	def _call_or_get(v):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12.2
+Flask>=0.12.2,<1.0
 Flask-SQLAlchemy>=2.3
 Flask-Login>=0.4.1
 Flask-User==0.6.19

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if not "FLASK_CONFIG" in os.environ:
 test_data = len(sys.argv) >= 2 and sys.argv[1].strip() == "-t"
 
 from app.models import *
+from app.utils import make_flask_user_password
 
 def defineDummyData(licenses, tags, ruben):
 	ez = User("Shara")
@@ -342,6 +343,8 @@ db.create_all()
 print("Filling database...")
 
 ruben = User("rubenwardy")
+ruben.active = True
+ruben.password = make_flask_user_password("tuckfrump")
 ruben.github_username = "rubenwardy"
 ruben.forums_username = "rubenwardy"
 ruben.rank = UserRank.ADMIN


### PR DESCRIPTION
Since commenting on the Package Update Detection issue (https://github.com/minetest/minetest/issues/7327#issuecomment-390450841), I've been taking a look at the codebase.
Here are some fixes to make running the server easier for development.

First commit prevents SERVER_NAME from being set in debug (FLASK_DEBUG) mode.
I've been getting unconditional 404 HTTP error responses when trying to run the server locally, and narrowed the issue down to this variable being set.
I assume the reason the current arrangement works for you is either defining an entry for content.minetest.net in /etc/hosts, or running the server on the very machine hosting content.minetest.net domain?

Second commit further restricts required Flask version.
https://pypi.org/project/Flask/#history
According to release history, Flask has recently bumped to the next major version, with some incompatibilities.
Attempting to run with a too-new Flask raises import errors.
Import namespace for Flask extensions seems to have changed, see https://github.com/pallets/flask/issues/1135#issuecomment-61860862
```
	Traceback (most recent call last):
	  File "/root/gittest/venv_flask/lib64/python3.6/site-packages/flask/cli.py", line 235, in locate_app
		__import__(module_name)
	  File "/root/gittest/contentdb/app/__init__.py", line 22, in <module>
		from flask.ext import markdown
	ModuleNotFoundError: No module named 'flask.ext'
```
For now just assure a sufficiently old Flask version is listed in requirements.

Third commit improves setup.py to create more of a real user for testing purposes.
It is now possible to login with a default password.