### PR TITLE
Add meta to package view pages

### DIFF
--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -6,6 +6,14 @@
 	{{ package.title }}
 {% endblock %}
 
+<meta name="og:title" content="{{ package.title }}"/>
+<meta name="og:description" content="{{ package.short_desc }}"/>
+<meta name="description" content="{{ package.short_desc }}"/>
+<meta name="og:url" content="{{ package.getDetailsURL() }}"/>
+{% if package.getMainScreenshotURL() %}
+<meta name="og:image" content="{{ package.getMainScreenshotURL() }}"/>
+{% endif %}
+
 {% block container %}
 	{% if not package.license.is_foss and not package.media_license.is_foss and package.type != package.type.TXP  %}
 		{% set package_warning="Non-free code and media" %}

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -6,13 +6,15 @@
 	{{ package.title }}
 {% endblock %}
 
-<meta name="og:title" content="{{ package.title }}"/>
-<meta name="og:description" content="{{ package.short_desc }}"/>
-<meta name="description" content="{{ package.short_desc }}"/>
-<meta name="og:url" content="{{ package.getDetailsURL() }}"/>
-{% if package.getMainScreenshotURL() %}
-<meta name="og:image" content="{{ package.getMainScreenshotURL() }}"/>
-{% endif %}
+{% block headextra %}
+	<meta name="og:title" content="{{ package.title }}"/>
+	<meta name="og:description" content="{{ package.short_desc }}"/>
+	<meta name="description" content="{{ package.short_desc }}"/>
+	<meta name="og:url" content="{{ package.getDetailsURL() }}"/>
+	{% if package.getMainScreenshotURL() %}
+	<meta name="og:image" content="{{ package.getMainScreenshotURL() }}"/>
+	{% endif %}
+{% endblock %}
 
 {% block container %}
 	{% if not package.license.is_foss and not package.media_license.is_foss and package.type != package.type.TXP  %}


### PR DESCRIPTION
Title says it all. Meta is useful for external previews. Note: untested.