### PR TITLE
Fix badges not displaying when dash (-) in title

### DIFF
--- a/app/blueprints/packages/packages.py
+++ b/app/blueprints/packages/packages.py
@@ -182,7 +182,7 @@ def view(package):
 @is_package_page
 def shield(package, type):
 	if type == "title":
-		url = "https://img.shields.io/badge/ContentDB-{}-{}" \
+		url = "https://img.shields.io/static/v1?label=ContentDB&message={}&color={}" \
 			.format(urlescape(package.title), urlescape("#375a7f"))
 	elif type == "downloads":
 		#api_url = abs_url_for("api.package", author=package.author.username, name=package.name)


### PR DESCRIPTION
Fixes badges not displaying when dash (-) in title.

### Example:

Changes badge URL from:
- `https://img.shields.io/badge/ContentDB-X-Decor-%23375a7f`

To:
- `https://img.shields.io/static/v1?label=ContentDB&message=X-Decor&color=%23375a7f`

Closes: #307