### PR TITLE
Display Minetest Icon on Shields/Badges

### DIFF
--- a/app/blueprints/packages/packages.py
+++ b/app/blueprints/packages/packages.py
@@ -182,12 +182,12 @@ def view(package):
 @is_package_page
 def shield(package, type):
 	if type == "title":
-		url = "https://img.shields.io/static/v1?label=ContentDB&message={}&color={}" \
+		url = "https://img.shields.io/static/v1?label=ContentDB&message={}&color={}&logo=minetest" \
 			.format(urlescape(package.title), urlescape("#375a7f"))
 	elif type == "downloads":
 		#api_url = abs_url_for("api.package", author=package.author.username, name=package.name)
 		api_url = "https://content.minetest.net" + url_for("api.package", author=package.author.username, name=package.name)
-		url = "https://img.shields.io/badge/dynamic/json?color={}&label=ContentDB&query=downloads&suffix=+downloads&url={}" \
+		url = "https://img.shields.io/badge/dynamic/json?color={}&label=ContentDB&query=downloads&suffix=+downloads&url={}&logo=minetest" \
 			.format(urlescape("#375a7f"), urlescape(api_url))
 	else:
 		abort(404)


### PR DESCRIPTION
Adds a Minetest icon to shields/badges.

Examples:
- Title: [![ContentDB](https://img.shields.io/static/v1?label=ContentDB&message=Wielded%20Light&color=%23375a7f&logo=minetest)](https://content.minetest.net/packages/bell07/wielded_light/)
- Downloads: [![ContentDB](https://img.shields.io/badge/dynamic/json?color=%23375a7f&label=ContentDB&query=downloads&suffix=+downloads&url=https%3A//content.minetest.net/api/packages/bell07/wielded_light/&logo=minetest)](https://content.minetest.net/packages/bell07/wielded_light/)

Icon provided to shields.io by simpleicons.org ([#53AC56](https://simpleicons.org/?q=minetest))