### PR TITLE
Fix missing space before "and" in package list

### DIFF
--- a/app/blueprints/admin/actions.py
+++ b/app/blueprints/admin/actions.py
@@ -187,10 +187,10 @@ def run_update_config():
 def _package_list(packages: List[str]):
 	# Who needs translations?
 	if len(packages) >= 3:
-		packages[len(packages) - 1] = "and " + packages[len(packages) - 1]
+		packages[len(packages) - 1] = " and " + packages[len(packages) - 1]
 		packages_list = ", ".join(packages)
 	else:
-		packages_list = "and ".join(packages)
+		packages_list = " and ".join(packages)
 	return packages_list
 
 @action("Send WIP package notification")

--- a/app/blueprints/admin/actions.py
+++ b/app/blueprints/admin/actions.py
@@ -187,7 +187,7 @@ def run_update_config():
 def _package_list(packages: List[str]):
 	# Who needs translations?
 	if len(packages) >= 3:
-		packages[len(packages) - 1] = " and " + packages[len(packages) - 1]
+		packages[len(packages) - 1] = "and " + packages[len(packages) - 1]
 		packages_list = ", ".join(packages)
 	else:
 		packages_list = " and ".join(packages)


### PR DESCRIPTION
Example message which I recently received:

> The following packages may be outdated: Gaugesand More Ores

This should now be:

> The following packages may be outdated: Gauges and More Ores