### PR TITLE
Fix Swedish language code

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,7 +42,7 @@ app.config["LANGUAGES"] = {
 	"pl": "Język Polski",
 	"ru": "русский язык",
 	"sk": "Slovenčina",
-	"sw": "Svenska",
+	"sv": "Svenska",
 	"zh_Hans": "汉语",
 }
 


### PR DESCRIPTION
Supposed to be `sv`, as `sw` is the language code for Swahili.