### PR TITLE
Fix invalid API route in docs for `.cdb.json` schema

### DIFF
--- a/app/flatpages/help/api.md
+++ b/app/flatpages/help/api.md
@@ -445,6 +445,6 @@ Supported query parameters:
     * `high_reviewed`:  highest reviewed
 * GET `/api/welcome/v1/` ([View](/api/welcome/v1/)) - in-menu welcome dialog. Experimental (may change without warning)
     * `featured`: featured games
-* GET `/api/cdb_schema/` ([View](/api/schema/))
+* GET `/api/cdb_schema/` ([View](/api/cdb_schema/))
     * Get JSON Schema of `.cdb.json`, including licenses, tags and content warnings.
     * See [JSON Schema Reference](https://json-schema.org/).


### PR DESCRIPTION
I am sorry :pensive:

I think I modified the name of the route after updating the docs.

Fix a problem with https://github.com/minetest/contentdb/pull/402