### PR TITLE
seo changes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -106,7 +106,7 @@ def send_upload(path):
 def flatpage(path):
 	page = pages.get_or_404(path)
 	template = page.meta.get("template", "flatpage.html")
-	return render_template(template, page=page)
+	return render_template(template, page=page, canonical_url=request.base_url)
 
 
 @app.before_request

--- a/app/blueprints/collections/__init__.py
+++ b/app/blueprints/collections/__init__.py
@@ -54,7 +54,7 @@ def list_all(author=None):
 	collections = [x for x in query.all() if x.check_perm(current_user, Permission.VIEW_COLLECTION)]
 	return render_template("collections/list.html",
 		user=user, collections=collections,
-		noindex=len(collections) == 0)
+		noindex=len(collections) == 0, canonical_url=request.base_url)
 
 
 @bp.route("/collections/<author>/<name>/")
@@ -70,7 +70,7 @@ def view(author, name):
 	if collection.check_perm(current_user, Permission.EDIT_COLLECTION):
 		items = [x for x in items if x.package.check_perm(current_user, Permission.VIEW_PACKAGE)]
 
-	return render_template("collections/view.html", collection=collection, items=items)
+	return render_template("collections/view.html", collection=collection, items=items, canonical_url=request.base_url)
 
 
 class CollectionForm(FlaskForm):

--- a/app/blueprints/homepage/__init__.py
+++ b/app/blueprints/homepage/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from flask import Blueprint, render_template, redirect
+from flask import Blueprint, render_template, redirect, request
 from sqlalchemy import and_
 
 from app.models import Package, PackageReview, Thread, User, PackageState, db, PackageType, PackageRelease, Tags, Tag, \
@@ -83,4 +83,4 @@ def home():
 
 	return render_template("index.html", count=count, downloads=downloads, tags=tags, spotlight_pkgs=spotlight_pkgs,
 			new=new, updated=updated, pop_mod=pop_mod, pop_txp=pop_txp, pop_gam=pop_gam, high_reviewed=high_reviewed,
-			reviews=reviews)
+			reviews=reviews, canonical_url=request.url_root)

--- a/app/blueprints/packages/packages.py
+++ b/app/blueprints/packages/packages.py
@@ -54,6 +54,12 @@ def generate_canonical(page, content_type, tag=None):
         'type': content_type
     }
 
+    if 'sort' in request.args:
+        query_params['sort'] = request.args.get('sort')
+
+    if 'order' in request.args:
+        query_params['order'] = request.args.get('order')
+
     encoded_query = urlencode(query_params)
 
     if tag:
@@ -63,7 +69,7 @@ def generate_canonical(page, content_type, tag=None):
     return f"{base_url}?{encoded_query}"
 
 @bp.route("/packages/")
-def list_all(type_name = False):
+def list_all():
 	qb    = QueryBuilder(request.args)
 	query = qb.build_package_query()
 	title = qb.title
@@ -223,7 +229,7 @@ def view(package):
 			package=package, releases=releases, packages_uses=packages_uses,
 			conflicting_modnames=conflicting_modnames,
 			review_thread=review_thread, topic_error=topic_error, topic_error_lvl=topic_error_lvl,
-			threads=threads.all(), has_review=has_review, is_favorited=is_favorited)
+			threads=threads.all(), has_review=has_review, is_favorited=is_favorited, canonical_url=request.base_url)
 
 
 @bp.route("/packages/<author>/<name>/shields/<type>/")

--- a/app/public/static/js/gallery_carousel.js
+++ b/app/public/static/js/gallery_carousel.js
@@ -10,3 +10,4 @@ document.querySelectorAll(".gallery-image").forEach(el => {
 		e.preventDefault();
 	});
 });
+

--- a/app/public/static/js/gallery_carousel.js
+++ b/app/public/static/js/gallery_carousel.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const galleryCarousel = new bootstrap.Carousel(document.querySelector('#galleryCarousel'));
+document.querySelectorAll('.gallery-image').forEach(el => {
+    el.addEventListener('click', function(e) {
+        galleryCarousel.to(el.dataset.bsSlideTo);
+    });
+});

--- a/app/public/static/js/gallery_carousel.js
+++ b/app/public/static/js/gallery_carousel.js
@@ -1,8 +1,12 @@
+// @author recluse4615
+// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3-or-Later
+
 "use strict";
 
-const galleryCarousel = new bootstrap.Carousel(document.querySelector('#galleryCarousel'));
-document.querySelectorAll('.gallery-image').forEach(el => {
-    el.addEventListener('click', function(e) {
-        galleryCarousel.to(el.dataset.bsSlideTo);
-    });
+const galleryCarousel = new bootstrap.Carousel(document.getElementById("galleryCarousel"));
+document.querySelectorAll(".gallery-image").forEach(el => {
+	el.addEventListener("click", function(e) {
+		galleryCarousel.to(el.dataset.bsSlideTo);
+		e.preventDefault();
+	});
 });

--- a/app/scss/comments.scss
+++ b/app/scss/comments.scss
@@ -1,3 +1,14 @@
+.breadcrumb {
+	background: none;
+	border: none;
+
+	.breadcrumb-item:not(.active) {
+		a {
+			color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+		}
+	}
+}
+
 .img-thumbnail-1 {
 	padding: 0px;
 	// width: 100%;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,6 +15,10 @@
 	<meta name="og:description" content="{{ self.description() | normalize_whitespace }}">
 	{%- endif %}
 
+	{% if canonical_url %}
+	<link rel="canonical" href="{{ canonical_url }}" />
+	{%- endif %}
+
 	<link rel="stylesheet" type="text/css" href="/static/libs/bootstrap.min.css?v=3">
 	<link rel="stylesheet" type="text/css" href="/static/custom.css?v=49">
 	<link rel="search" type="application/opensearchdescription+xml" href="/static/opensearch.xml" title="ContentDB" />

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ self.title() | normalize_whitespace }} - {{ config.USER_APP_NAME }}</title>
+	<title>{{ self.title() | normalize_whitespace }} | {{ config.USER_APP_NAME }}</title>
 	<link rel="shortcut icon" href="/favicon-16.png" sizes="16x16">
 	<link rel="icon" href="/favicon-128.png" sizes="128x128">
 	<link rel="icon" href="/favicon-32.png" sizes="32x32">

--- a/app/templates/collections/list.html
+++ b/app/templates/collections/list.html
@@ -21,8 +21,42 @@
 				{{ _("Create") }}
 			</a>
 		{% endif %}
+		<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+			<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}" title="Go to home page" itemprop="item">
+					<span itemprop="name">Home</span>
+					<meta itemprop="position" content="1" />
+				</a>
+			</li>
+			<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}collections" title="Go to collections" itemprop="item">
+					<span itemprop="name">Collections</span>
+					<meta itemprop="position" content="2" />
+				</a>
+			</li>
+			<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.base_url }}" title="Go to {{ user.username }}s collections" itemprop="item">
+					<span itemprop="name">{{ user.username }}</span>
+					<meta itemprop="position" content="3" />
+				</a>
+			</li>
+		</ol>
 		<h1>{{ _("%(author)s's collections", author=self.author_link()) }}</h1>
 	{% else %}
+		<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+			<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}" title="Go to home page" itemprop="item">
+					<span itemprop="name">Home</span>
+					<meta itemprop="position" content="1" />
+				</a>
+			</li>
+			<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}collections" title="Go to collections" itemprop="item">
+					<span itemprop="name">Collections</span>
+					<meta itemprop="position" content="2" />
+				</a>
+			</li>
+		</ol>
 		<h1>{{ _("Collections") }}</h1>
 	{% endif %}
 

--- a/app/templates/flatpage.html
+++ b/app/templates/flatpage.html
@@ -9,6 +9,22 @@
 {% block container %}
 
 {% set html = page.html %}
+<div class="container pt-4">
+	<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+		<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+			<a href="{{ request.url_root }}" title="Go to home page" itemprop="item">
+				<span itemprop="name">Home</span>
+				<meta itemprop="position" content="1" />
+			</a>
+		</li>
+		<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+			<a href="{{ request.base_url }}" title="Go to {{ page['title'] }}" itemprop="item">
+				<span itemprop="name">{{ page['title'] }}</span>
+				<meta itemprop="position" content="2" />
+			</a>
+		</li>
+	</ol>
+</div>
 {% if page.meta.get("toc", True) %}
 	<div class="container mt-4">
 		<main class="d-flex gap-5 flex-column flex-md-row-reverse">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ _("Welcome") }}
+{{ _("Discover new content for Minetest") }}
 {% endblock %}
 
 {% block description %}
-{{ _("Welcome to the best place to find Minetest mods, games, and texture packs") }}
+{{ _("Minetest ContentDB allows users to discover thousands of free games, mods, and texture packs, all usable within the Minetest Engine.") }}
 {% endblock %}
 
 {% block scriptextra %}

--- a/app/templates/macros/reviews.html
+++ b/app/templates/macros/reviews.html
@@ -23,7 +23,7 @@
 <ul class="comments mt-4 mb-0">
 	{% for review in reviews %}
 		{% set review_anchor = "review-" + (review.id | string) %}
-		<li class="row my-2 mx-0">
+		<li class="row my-2 mx-0" itemscope itemprop="review" itemtype="https://schema.org/Review">
 			<a id="{{ review_anchor }}"></a>
 			<div class="col-md-1 p-1">
 				<a href="{{ url_for('users.profile', username=review.author.username) }}">
@@ -31,7 +31,10 @@
 						src="{{ review.author.get_profile_pic_url() }}" loading="lazy">
 				</a>
 			</div>
-			<div class="col-md-auto ps-1 pe-3 pt-2 text-center" style=" font-size: 200%;">
+			<div class="col-md-auto ps-1 pe-3 pt-2 text-center" style=" font-size: 200%;" itemscope itemprop="reviewRating" itemtype="https://schema.org/Rating">
+				<meta itemprop="worstRating" content="1" />
+				<meta itemprop="bestRating" content="5" />
+				<meta itemProp="ratingValue" content="{{ review.rating }}" />
 				{% if review.rating > 3 %}
 					<i class="fas fa-thumbs-up" style="color:#6f6;"></i>
 				{% elif review.rating < 3 %}
@@ -46,12 +49,12 @@
 					<div class="card">
 						<div class="card-header">
 							<a class="author {{ review.author.rank.name }}"
-									href="{{ url_for('users.profile', username=review.author.username) }}">
+									href="{{ url_for('users.profile', username=review.author.username) }}" itemprop="author">
 								{{ review.author.display_name }}
 							</a>
 
 							<a name="reply-{{ reply.id }}" class="text-muted float-end"
-									href="{{ url_for('threads.view', id=review.thread.id) }}#reply-{{ reply.id }}">
+									href="{{ url_for('threads.view', id=review.thread.id) }}#reply-{{ reply.id }}" itemprop="datePublished">
 								{{ review.created_at | datetime }}
 							</a>
 						</div>
@@ -65,10 +68,10 @@
 							{% endif %}
 
 							<p>
-								<strong>{{ review.thread.title }}</strong>
+								<strong itemprop="name">{{ review.thread.title }}</strong>
 							</p>
 
-							{{ reply.comment | markdown }}
+							<span itemprop="reviewBody">{{ reply.comment | markdown }}</span>
 
 							<div class="btn-toolbar mt-2 mb-0">
 								{% if show_package_link %}

--- a/app/templates/packages/list.html
+++ b/app/templates/packages/list.html
@@ -23,6 +23,21 @@
 	{% endif %}
 
 	<aside class="mb-5">
+		<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+			<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}" title="Go to home page" itemprop="item">
+					<span itemprop="name">Home</span>
+					<meta itemprop="position" content="1" />
+				</a>
+			</li>
+			<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+				<a href="{{ request.url_root }}packages/?type={{ type }}" title="Go to {{ query_hint }}" itemprop="item">
+					<span itemprop="name">{{ query_hint }}</span>
+					<meta itemprop="position" content="2" />
+				</a>
+			</li>
+		</ol>
+
 		<p class="text-muted">{{ _("Filter by tags") }}</p>
 
 		{% for pair in tags %}

--- a/app/templates/packages/list.html
+++ b/app/templates/packages/list.html
@@ -1,7 +1,15 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ query_hint or _("Packages") }}
+{% if query_hint %}
+	Browse {{ query_hint }}
+{% else %}
+	{{ _("Packages") }}
+{% endif %}
+{% endblock %}
+
+{% block description %}
+	Discover and download new {{ query_hint | lower }} for Minetest here. Enhance your Minetest experience with thousands of free games, mods, and texture packs!
 {% endblock %}
 
 {% block author_links %}

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -250,9 +250,9 @@
 				{% endif %}
 
 				{% if screenshots or package.check_perm(current_user, "ADD_SCREENSHOTS") or package.video_url %}
-					{% if screenshots or package.check_perm(current_user, "ADD_SCREENSHOTS") %}
+					{% if screenshots %}
 						<div class="modal fade" id="galleryModal" tabindex="-1" role="dialog" aria-hidden="true">
-							<div class="modal-dialog modal-lg">
+							<div class="modal-dialog modal-xl">
 								<div class="modal-content">
 									<div class="modal-body">
 										<div id="galleryCarousel" class="carousel slide">

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -268,11 +268,11 @@
 												{% endfor %}
 												<button class="carousel-control-prev" data-bs-target="#galleryCarousel" role="button" data-bs-slide="prev">
 													<span class="carousel-control-prev-icon" aria-hidden="true"></span>
-													<span class="sr-only">Previous</span>
+													<span class="sr-only">{{ _("Previous") }}</span>
 												</button>
 												<button class="carousel-control-next" data-bs-target="#galleryCarousel" role="button" data-bs-slide="next">
 													<span class="carousel-control-next-icon" aria-hidden="true"></span>
-													<span class="sr-only">Next</span>
+													<span class="sr-only">{{ _("Next") }}</span>
 												</button>
 											</div>
 										</div>
@@ -297,7 +297,7 @@
 							{% for ss in screenshots %}
 								{% if ss.approved or package.check_perm(current_user, "ADD_SCREENSHOTS") %}
 									<li>
-										<a href="#" data-bs-toggle="modal" data-bs-target="#galleryModal" data-bs-slide-to="{{ loop.index - 1 }}" class="gallery-image">
+										<a href="{{ ss.url }}" data-bs-toggle="modal" data-bs-target="#galleryModal" data-bs-slide-to="{{ loop.index - 1 }}" class="gallery-image">
 											<img src="{{ ss.get_thumb_url() }}" alt="{{ ss.title }}" title="{{ ss.title }}" />
 											{% if not ss.approved %}
 												<span class="badge bg-dark badge-tr">{{ _("Awaiting review") }}</span>

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -19,6 +19,7 @@
 
 {% block scriptextra %}
 	<script src="/static/js/video_embed.js"></script>
+	<script src="/static/js/gallery_carousel.js"></script>
 	{% if current_user.is_authenticated %}
 		<script src="/static/js/quick_review_voting.js"></script>
 	{% endif %}
@@ -76,6 +77,7 @@
 	{% elif not package.media_license.is_foss %}
 		{% set package_warning=_("Non-free media") %}
 	{% endif %}
+
 <main>
 	{% if not package.approved %}
 		<section class="my-4 pb-3" style="">
@@ -248,6 +250,37 @@
 				{% endif %}
 
 				{% if screenshots or package.check_perm(current_user, "ADD_SCREENSHOTS") or package.video_url %}
+					{% if screenshots or package.check_perm(current_user, "ADD_SCREENSHOTS") %}
+						<div class="modal fade" id="galleryModal" tabindex="-1" role="dialog" aria-hidden="true">
+							<div class="modal-dialog modal-lg">
+								<div class="modal-content">
+									<div class="modal-body">
+										<div id="galleryCarousel" class="carousel slide">
+											<div class="carousel-inner">
+												{% for ss in screenshots %}
+												{% if ss.approved or package.check_perm(current_user, "ADD_SCREENSHOTS") %}
+												<div class="carousel-item {% if loop.index == 1 %}active{% endif %}">
+													<a href="{{ ss.url }}" target="_blank">
+														<img class="img-size w-100" src="{{ ss.url }}" alt="{{ ss.title }}" title="{{ ss.title }}" />
+													</a>
+												</div>
+												{% endif %}
+												{% endfor %}
+												<button class="carousel-control-prev" data-bs-target="#galleryCarousel" role="button" data-bs-slide="prev">
+													<span class="carousel-control-prev-icon" aria-hidden="true"></span>
+													<span class="sr-only">Previous</span>
+												</button>
+												<button class="carousel-control-next" data-bs-target="#galleryCarousel" role="button" data-bs-slide="next">
+													<span class="carousel-control-next-icon" aria-hidden="true"></span>
+													<span class="sr-only">Next</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					{% endif %}
 					<ul class="gallery">
 						{% if package.video_url %}
 							<li>
@@ -264,7 +297,7 @@
 							{% for ss in screenshots %}
 								{% if ss.approved or package.check_perm(current_user, "ADD_SCREENSHOTS") %}
 									<li>
-										<a href="{{ ss.url }}" class="gallery-image">
+										<a href="#" data-bs-toggle="modal" data-bs-target="#galleryModal" data-bs-slide-to="{{ loop.index - 1 }}" class="gallery-image">
 											<img src="{{ ss.get_thumb_url() }}" alt="{{ ss.title }}" title="{{ ss.title }}" />
 											{% if not ss.approved %}
 												<span class="badge bg-dark badge-tr">{{ _("Awaiting review") }}</span>

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -15,6 +15,19 @@
 	{% if package.get_thumb_url(3, True) -%}
 		<meta name="og:image" content="{{ package.get_thumb_url(3, True) }}"/>
 	{%- endif %}
+
+	<script type="application/ld+json">
+		{
+			"@context": "https://schema.org",
+			"@type": "SoftwareApplication",
+			"downloadUrl": "{{ request.url_root }}{{ release.get_download_url()[1:] }}",
+		{% if package.get_thumb_url(3, True) -%}
+				"screenshot": "{{ package.get_thumb_url(3, True) }}",
+		{%- endif %}
+			"name": "{{ package.title }}",
+			"about": "{{ package.short_desc }}"
+		}
+	</script>
 {% endblock %}
 
 {% block scriptextra %}
@@ -127,6 +140,27 @@
 					</a>
 				{% endif %}
 			</div>
+
+			<ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+				<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+					<a href="{{ request.url_root }}" title="Go to home page" itemprop="item">
+						<span itemprop="name">Home</span>
+						<meta itemprop="position" content="1" />
+					</a>
+				</li>
+				<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+					<a href="{{ request.url_root }}packages/?type={{ package.type.name }}" title="Go to {{ package.type.value }}" itemprop="item">
+						<span itemprop="name">{{ package.type.value }}</span>
+						<meta itemprop="position" content="2" />
+					</a>
+				</li>
+				<li class="breadcrumb-item active" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+					<a href="{{ request.url_root }}{{ request.path[1:] }}" title="Go to {{ package.title }}" itemprop="item">
+						<span itemprop="name">{{ package.title }}</span>
+						<meta itemprop="position" content="3" />
+					</a>
+				</li>
+			</ol>
 
 			<h1 class="display-3">
 				{{ package.title }}

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -149,7 +149,7 @@
 					</a>
 				</li>
 				<li class="breadcrumb-item" itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
-					<a href="{{ request.url_root }}packages/?type={{ package.type.name }}" title="Go to {{ package.type.value }}" itemprop="item">
+					<a href="{{ request.url_root }}packages/?type={{ package.type.name | lower }}" title="Go to {{ package.type.value }}" itemprop="item">
 						<span itemprop="name">{{ package.type.value }}</span>
 						<meta itemprop="position" content="2" />
 					</a>


### PR DESCRIPTION
(i need to redo this branch, because i based it off of my local modal branch and it's pulling in likely incorrect commits)

current changes:
- adding in json-ld for individual packages (incl. reviews)
- adding in breadcrumbs for most pages (mostly as a nicer UX, but also json-ld breadcrumbs)
- adding self-canonicalisation to some pages (need to expand this to other pages)

most of this pr is fine to go straight to production, but would mostly appreciate feedback on implementation/changes to make (i have next to no experience w/ python and absolutely none with flask)

changes i want to work on:
- expansion of opengraph data where possible
- more json-ld data where needed (flat pages = article, etc)
- friendlier urls instead of `/packages/?type=txp` (a bigger task since we can have them as extra home pages..)
- canonicalisation of other pages
- moving locales to different directories, eg `/en-us/`, `/fr-fr/`