### PR TITLE
Fix statistics reporting the 5.10 client as web

### DIFF
--- a/utils/import_nginx_logs.py
+++ b/utils/import_nginx_logs.py
@@ -131,7 +131,7 @@ for log_file in log_files:
 				db.session.add(row)
 				row_lookup[key] = row
 
-			if ua.startswith("Minetest/"):
+			if ua.startswith("Minetest/") or ua.startswith("Luanti/"):
 				row.platform_minetest += 1
 			else:
 				row.platform_other += 1


### PR DESCRIPTION
The user agent was changed in 5.10 to Luanti which makes CDB's statistics think it is regular web traffic (see staff channel). This should fix it for future statistics, but assumedly not retroactively for already processed statistics.