### PR TITLE
Lazy load package thumbnails on translate/donate pages

### DIFF
--- a/app/templates/donate/index.html
+++ b/app/templates/donate/index.html
@@ -25,7 +25,8 @@
 							<img
 								class="img-fluid"
 								style="max-height: 22px; max-width: 22px;"
-								src="{{ package.get_thumb_or_placeholder() }}" />
+								src="{{ package.get_thumb_or_placeholder() }}"
+								loading="lazy" />
 
 							<span class="ps-2">
 								{{ package.title }}


### PR DESCRIPTION
So it does not cause ratelimits when trying to load all the hundreds of package thumbnails all at once in the package translation page.