### PR TITLE
Fix "You have a lot of notifications" reminder with read notifications

### DIFF
--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -42,7 +42,7 @@ def post_login(user: User, next_url):
 	if not current_user.password:
 		return redirect(url_for("users.set_password"))
 
-	notif_count = user.notifications.count()
+	notif_count = user.notifications.filter_by(read_at=None).count()
 	if notif_count > 0:
 		if notif_count >= 10:
 			flash(gettext("You have a lot of notifications, you should either read or clear them"), "info")


### PR DESCRIPTION
Fixes the "You have a lot of notifications" reminder to not count read notifications.

Not tested, but looks like how it should be from this other code for getting unread notifs: https://github.com/luanti-org/contentdb/blob/02aef8b3d0901a8bdea4d9965fedc8f6cc15f813/app/templates/base.html#L112