### PR TITLE
Readd `download` attribute to download buttons

### DIFF
--- a/app/public/static/js/download_card.js
+++ b/app/public/static/js/download_card.js
@@ -30,6 +30,8 @@ function setLuantiVersion(version) {
 	localStorage.setItem("luanti-version", version.value);
 
 	const {
+		packageName,
+		releaseId,
 		releaseName,
 		releaseUrl,
 		releaseSize,
@@ -52,6 +54,10 @@ function setLuantiVersion(version) {
 
 		const btn = document.querySelector("#download-card .btn-download");
 		btn.setAttribute("href", releaseUrl);
+
+		// See PackageRelease.get_download_filename()
+		const filename = `${packageName}_${releaseId}.zip`;
+		btn.setAttribute("download", filename);
 
 		const size = document.getElementById("download-file-size");
 		if (releaseSize > 1024*1024) {

--- a/app/templates/packages/view.html
+++ b/app/templates/packages/view.html
@@ -290,9 +290,11 @@
 										{% if version_release %}
 											{% set id, name, file_size_bytes, created_at, _ = version_release %}
 											data-release-url="{{ package.get_url('packages.download_release', id=id) }}"
+											data-package-name="{{ package.name }}"
+											data-release-id="{{ id }}"
 											data-release-name="{{ name }}"
 											data-release-size="{{ file_size_bytes }}"
-											data-release-created-at="{{ created_at | datetime }} "
+											data-release-created-at="{{ created_at | datetime }}"
 										{% endif %}
 										{% if loop.index == (luanti_versions | length) - 1 %}selected{% endif %}
 										{% if loop.index >= (luanti_versions | length) - 1 %}data-latest="true"{% endif %}>
@@ -701,7 +703,7 @@
 										{{ release.name }}
 									</p>
 									<p>
-										<a href="{{ release.get_download_url() }}" class="btn btn-secondary me-3">
+										<a href="{{ release.get_download_url() }}" download="{{ release.get_download_filename() }}" class="btn btn-secondary me-3">
 											{{ _("Download") }}
 										</a>
 									</p>


### PR DESCRIPTION
Readd `download` attributes to download buttons in the package view that disappeared during the redesign. 

Note for testing: The development server serves static uploads with a `Content-Disposition` header which makes browsers override the value in `download`, but in production nginx serves them without any such header.